### PR TITLE
Install script

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# get this script's directory
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+cd $DIR
+# for some reason, even if `nvm` worked in the console
+# this script would error with `nvm command not found`
+source $NVM_DIR/nvm.sh
+# activate appropriate Nodejs version
+nvm use 5.0.0
+# launch openframe!
+node frame.js "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,4 +25,7 @@ cd $DIR
 cd ..
 npm install
 
+echo ""
 echo "You must restart your shell, or run the following command: source ~/.bashrc"
+echo "After reloading .bashrc, you can launch the frame with: $DIR/../launch.sh -u [USERNAME] -f [FRAME_NAME] -d [DOMAIN]"
+echo "For example: $DIR/../launch.sh -u jonwohl -f Home -d openframe.io"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# get this script's directory
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# elevate to root
+echo ""
+sudo -v -p "Please enter the administrator's password: "
+
+# install NVM for easy node version management
+curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | sh
+# source nvm to access it in the shell
+# usually it is source in .bashrc, 
+# but we can't reload .bashrc within a script
+source ~/.nvm/nvm.sh
+# install latest tested stable Nodejs
+nvm install 5.0.0
+# set 5.0.0 as default system Nodejs version
+# this means 5.0.0 will be in the $PATH when you boot
+nvm alias default 5.0.0
+
+# install chromium from package repository
+sudo apt-get update
+sudo apt-get install chromium
+
+# now install Nodejs dependencies
+cd $DIR
+cd ..
+npm install
+
+echo "You must restart your shell, or run the following command: source ~/.bashrc"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,9 +15,6 @@ curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | sh
 source ~/.nvm/nvm.sh
 # install latest tested stable Nodejs
 nvm install 5.0.0
-# set 5.0.0 as default system Nodejs version
-# this means 5.0.0 will be in the $PATH when you boot
-nvm alias default 5.0.0
 
 # install chromium from package repository
 sudo apt-get update


### PR DESCRIPTION
added an installation and launch script

two benefits:
1. doesn't add repositories to the package manager
2. doesn't mess with the system Nodejs version, and will keep working if the system Nodejs version is incompatible

nice-to-have:
- manage stdout
- script for setting up auto-launch, and possibly auto-shutdown

next steps:
- update Wiki
